### PR TITLE
feature/collections

### DIFF
--- a/iiif/manifest.py
+++ b/iiif/manifest.py
@@ -109,11 +109,14 @@ class Manifest(IIIFObject):
         return None
     
     def build_absolute_uri(self, url_name, url_args):
-        reversed_url = reverse(url_name, args=url_args)
+        reversed_url = reverse(url_name, kwargs=url_args)
         return self.request.build_absolute_uri(reversed_url)
 
     def build_url(self):
-        return self.build_absolute_uri('iiif:manifest', [self.id])
+        return self.build_absolute_uri('iiif:manifest', {
+            'manifest_id': self.id,
+            'object_type': 'manifest',
+        })
 
     def to_dict(self):
         manifest = {
@@ -138,7 +141,11 @@ class Sequence(IIIFObject):
         return canvas
     
     def build_url(self):
-        return self.manifest.build_absolute_uri('iiif:sequence', [self.manifest.id, 'sequence', self.id])
+        return self.manifest.build_absolute_uri('iiif:sequence', {
+            'manifest_id': self.manifest.id,
+            'object_type': 'sequence',
+            'object_id': self.id
+        })
 
     def to_dict(self):
         sequence = {
@@ -164,7 +171,11 @@ class Canvas(IIIFObject):
         self.label = label
         
     def build_url(self):
-        return self.manifest.build_absolute_uri('iiif:canvas', [self.manifest.id, 'canvas', self.id])
+        return self.manifest.build_absolute_uri('iiif:canvas', {
+            'manifest_id': self.manifest.id,
+            'object_type': 'canvas',
+            'object_id': self.id
+        })
 
     def to_dict(self):
         canvas = {
@@ -189,7 +200,11 @@ class ImageResource(IIIFObject):
         self.is_link = is_link
         
     def build_url(self):
-        return self.manifest.build_absolute_uri('iiif:resource', [self.manifest.id, 'resource', self.id])
+        return self.manifest.build_absolute_uri('iiif:resource', {
+            'manifest_id': self.manifest.id,
+            'object_type': 'resource',
+            'object_id': self.id
+        })
 
     def to_dict(self):
         if self.is_link:

--- a/iiif/urls.py
+++ b/iiif/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
 from .views import manifest
 urlpatterns = [
-    url(r'^(\d+)/manifest.json$', manifest, name='manifest'),
-    url(r'^(\d+)/(sequence)/(\d+).json$', manifest, name='sequence'),
-    url(r'^(\d+)/(canvas)/(\d+).json$', manifest, name='canvas'),
-    url(r'^(\d+)/(resource)/(\d+).json$', manifest, name='resource'),
+    url(r'^(?P<manifest_id>[0-9:]+)/(?P<object_type>manifest).json$', manifest, name='manifest'),
+    url(r'^(?P<manifest_id>[0-9:]+)/(?P<object_type>sequence)/(?P<object_id>\d+).json$', manifest, name='sequence'),
+    url(r'^(?P<manifest_id>[0-9:]+)/(?P<object_type>canvas)/(?P<object_id>\d+).json$', manifest, name='canvas'),
+    url(r'^(?P<manifest_id>[0-9:]+)/(?P<object_type>resource)/(?P<object_id>\d+).json$', manifest, name='resource'),
 ]

--- a/mirador/admin.py
+++ b/mirador/admin.py
@@ -1,11 +1,15 @@
 from django.contrib import admin
-from .models import IsiteImages, LTICourseImages
+from .models import IsiteImages, LTICourseImages, LTICourseCollections
 
 class IsiteImagesAdmin(admin.ModelAdmin):
     list_display = ('id', 'isite_keyword', 'isite_topic_id','isite_file_name', 'isite_file_url', 'isite_file_title', 'isite_file_description', 's3_bucket', 's3_key', 'created')
 
 class LTICourseImagesAdmin(admin.ModelAdmin):
-    list_display = ('id', 'course', 'isite_image')
+    list_display = ('id', 'course', 'isite_image', 'created')
+    
+class LTICourseCollectionsAdmin(admin.ModelAdmin):
+    list_display = ('id', 'label', 'sort_order', 'created')
 
 admin.site.register(IsiteImages, IsiteImagesAdmin)
 admin.site.register(LTICourseImages, LTICourseImagesAdmin)
+admin.site.register(LTICourseCollections, LTICourseCollectionsAdmin)

--- a/mirador/migrations/0001_initial.py
+++ b/mirador/migrations/0001_initial.py
@@ -28,9 +28,24 @@ class Migration(migrations.Migration):
                 ('updated', models.DateTimeField(auto_now=True)),
             ],
             options={
-                'ordering': ['isite_keyword', 'isite_topic_id', 'isite_file_type', 'isite_file_name'],
+                'ordering': ['id'],
                 'verbose_name': 'Isite Image',
                 'verbose_name_plural': 'Isite Images',
+            },
+        ),
+        migrations.CreateModel(
+            name='LTICourseCollections',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('label', models.CharField(max_length=128)),
+                ('sort_order', models.IntegerField(default=0)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'ordering': ['id'],
+                'verbose_name': 'LTI Course Collection',
+                'verbose_name_plural': 'LTI Course Collections',
             },
         ),
         migrations.CreateModel(
@@ -39,6 +54,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('updated', models.DateTimeField(auto_now=True)),
+                ('collection', models.ForeignKey(to='mirador.LTICourseCollections', null=True)),
                 ('course', models.ForeignKey(to='django_app_lti.LTICourse')),
                 ('isite_image', models.ForeignKey(to='mirador.IsiteImages')),
             ],

--- a/mirador/models.py
+++ b/mirador/models.py
@@ -32,7 +32,7 @@ class LTICourseCollections(models.Model):
         return "%s - %s" % (self.id, self.label)
 
     class Meta:
-        ordering = ['id']
+        ordering = ['sort_order']
         verbose_name = 'LTI Course Collection'
         verbose_name_plural = 'LTI Course Collections'
 

--- a/mirador/models.py
+++ b/mirador/models.py
@@ -21,15 +21,30 @@ class IsiteImages(models.Model):
         ordering = ['id']
         verbose_name = 'Isite Image'
         verbose_name_plural = 'Isite Images'
-        
+
+class LTICourseCollections(models.Model):
+    label = models.CharField(max_length=128)
+    sort_order = models.IntegerField(null=False, default=0)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    def __unicode__(self):
+        return "%s - %s" % (self.id, self.label)
+
+    class Meta:
+        ordering = ['id']
+        verbose_name = 'LTI Course Collection'
+        verbose_name_plural = 'LTI Course Collections'
+
 class LTICourseImages(models.Model):
     course = models.ForeignKey(LTICourse)
+    collection = models.ForeignKey(LTICourseCollections, null=True)
     isite_image = models.ForeignKey(IsiteImages)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
-        return "%s: %s" % (self.course, self.isite_image)
+        return "%s - %s" % (self.collection, self.isite_image)
 
     @classmethod
     def get_lti_course(self, course_id):

--- a/mirador/templates/mirador.html
+++ b/mirador/templates/mirador.html
@@ -25,7 +25,7 @@
         // This data array holds the manifest URIs for the IIIF resources you want Mirador to make available to the user.
         // Each manifest object must have a manifest URI pointing to a valid IIIF manifest, and may also
         // provide a location to be displayed in the listing of available manifests.
-        "data": {% autoescape off %}{{ manifest_data_json }}{% endautoescape %}, 
+        "data": {% autoescape off %}{{ manifests_json }}{% endautoescape %}, 
         
         // This array allows the user to specify which of the included manifests should appear 
         // in the workspace, and what the configuration of the window (zoom level, open panels, etc.) 

--- a/mirador/views.py
+++ b/mirador/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
-from .models import LTICourseImages
+from .models import LTICourseImages, LTICourseCollections
 import json
 
 def _build_manifest_uri(request, manifest_id):
@@ -19,10 +19,13 @@ def index(request, course_id):
     }]
 
     # Add manifest for each collection of images
-    collections = LTICourseImages.objects.values('collection').distinct()
+    collection_ids = LTICourseImages.objects.filter(course__id=course_id).distinct().values_list('collection', flat=True)
+    collections = []
+    if len(collection_ids) > 0:
+        collections = LTICourseCollections.objects.filter(id__in=collection_ids).order_by('sort_order', 'label')
+
     for collection in collections:
-        collection_id = collection['collection']
-        manifest_id = "%s:%s" % (course_id, collection_id)
+        manifest_id = "%s:%s" % (course_id, collection.id)
         manifests.append({
             "manifestUri": _build_manifest_uri(request, manifest_id),
             "location": "Harvard University",

--- a/mirador/views.py
+++ b/mirador/views.py
@@ -1,15 +1,31 @@
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
+from .models import LTICourseImages
 import json
+
+def _build_manifest_uri(request, manifest_id):
+    return request.build_absolute_uri(reverse("iiif:manifest", kwargs={
+        'manifest_id': manifest_id,
+        'object_type': 'manifest',
+    }))
 
 def index(request, course_id):
     '''Renders the page with Mirador, which loads the images specified by the IIIF manifest.'''
 
-    manifest_url = reverse("iiif:manifest", args=[course_id])
-    manifest_data = [{
-        "manifestUri": request.build_absolute_uri(manifest_url),
+    # Add manifest of images for the whole course (across collections)
+    manifests = [{
+        "manifestUri": _build_manifest_uri(request, course_id),
         "location": "Harvard University",
     }]
-    context = {"manifest_data_json": json.dumps(manifest_data)}
 
-    return render(request, 'mirador.html', context)
+    # Add manifest for each collection of images
+    collections = LTICourseImages.objects.values('collection').distinct()
+    for collection in collections:
+        collection_id = collection['collection']
+        manifest_id = "%s:%s" % (course_id, collection_id)
+        manifests.append({
+            "manifestUri": _build_manifest_uri(request, manifest_id),
+            "location": "Harvard University",
+        })
+
+    return render(request, 'mirador.html', {"manifests_json": json.dumps(manifests)})


### PR DESCRIPTION
This PR refactors the code so that images can be associated with collections. After images have been imported, they can be mapped from **keyword/topic** to **course/collection**.

The URL format has been extended as follows:

```
/iiif/{course_id}/manifest.json
/iiif/{course_id}:{collection_id}/manifest.json
```

The URL format allows the client to request _all_ images for the course, or images for a particular collection in the course. When the tool is launched, Mirador is populated with a list of manifest URIs. The first manifest lists _all_ images in the course, and then subsequent manifests are collection-specific. 

Here's a screenshot of a course's collections in Mirador (images assigned from iSIte k104604 and sub-divided into collections by topic ID):

![screen shot 2015-08-11 at 10 39 28 am](https://cloud.githubusercontent.com/assets/1165361/9200324/4ddbad10-4015-11e5-9ec5-649863bb2081.png)
